### PR TITLE
Increased Touch Sensitivity

### DIFF
--- a/src/js/addons/jquery.tosrus.drag.js
+++ b/src/js/addons/jquery.tosrus.drag.js
@@ -124,7 +124,7 @@
 								else
 								{
 									var slideWidth = that.nodes.$slides.first().width(),
-										slides = Math.floor( ( Math.abs( _distance ) + ( slideWidth / 2 ) ) / slideWidth );	
+										slides = Math.floor( ( Math.abs( _distance ) + ( slideWidth * .95 ) ) / slideWidth );	
 								}
 		
 								if ( slides > 0 )


### PR DESCRIPTION
on mobile, it requires the user to swipe half the screen before next or prev is initiated . With slideWidth*.95  only 5% is required to trigger next slide on swipe. Works much better on tablets.