### PR TITLE
Fix bag: Didn't work dynamic event handlers on elements of wrapper

### DIFF
--- a/src/js/jquery.tosrus.js
+++ b/src/js/jquery.tosrus.js
@@ -100,7 +100,8 @@
 				.on( _e.click,
 					function( e )
 					{
-						e.stopPropagation();
+						if( that.opts.wrapper.onClick != null )
+							e.stopPropagation();
 
 						switch ( that.opts.wrapper.onClick )
 						{


### PR DESCRIPTION
Don't work event handlers on elements of wrapper: 
```
$('body').on('click', '.wrapper .innerElement', function(e) {
  console.log('event');
});
```
This pull request fix it. But need set onClick to null:
```
  wrapper : {
    onClick: null
  },
```
